### PR TITLE
Add config option for use of redis

### DIFF
--- a/config.js.example
+++ b/config.js.example
@@ -94,6 +94,13 @@ exports.ConfigSettings = {
         connectionRateLimit: {
             enabled: false,
             connectionRateLimitPerIP: 10 // num of new connections per second per ip
-        }
+        },
+
+        // Whether to use redis for detached reloading
+        redis: {
+            enabled: false,
+            host: "localhost",
+            port: 6379
+        },
     }
 };

--- a/node_modules/dimensions/configloader.ts
+++ b/node_modules/dimensions/configloader.ts
@@ -44,6 +44,12 @@ export interface ConnectionRateLimit {
   connectionRateLimitPerIP: number;
 }
 
+export interface RedisConfig {
+  enabled: boolean;
+  host: string;
+  port: number;
+}
+
 export interface ConfigOptions {
   socketTimeout: number;
   socketNoDelay: boolean;
@@ -55,6 +61,7 @@ export interface ConfigOptions {
   log: LogOptions;
   connectionLimit: ConnectionLimit;
   connectionRateLimit: ConnectionRateLimit;
+  redis: RedisConfig;
 }
 
 export interface Config {

--- a/node_modules/dimensions/index.ts
+++ b/node_modules/dimensions/index.ts
@@ -1,4 +1,4 @@
-import * as redis from "redis";
+import * as redis from 'redis';
 import RoutingServer from 'dimensions/routingserver';
 import ListenServerArgs from 'dimensions/listenserverargs';
 import ListenServer from 'dimensions/listenserver';

--- a/node_modules/dimensions/index.ts
+++ b/node_modules/dimensions/index.ts
@@ -1,4 +1,4 @@
-import * as redis from 'redis';
+import * as redis from "redis";
 import RoutingServer from 'dimensions/routingserver';
 import ListenServerArgs from 'dimensions/listenserverargs';
 import ListenServer from 'dimensions/listenserver';
@@ -44,19 +44,9 @@ class Dimensions {
     };
 
     Extensions.loadExtensions(this.handlers.extensions, this.listenServers, this.options.log, this.logging);
-
-    // Start a client listening on the dimensions_cli channel for commands, such as reload
-    this.redisClient = redis.createClient();
-    this.redisClient.subscribe('dimensions_cli');
-    this.redisClient
-      .on('message', (channel: string, message: string) => {
-        if (channel === "dimensions_cli") {
-          this.handleCommand(message);
-        }
-      })
-      .on('error', (err: Error) => {
-        console.log("RedisError: " + err);
-      });
+    if (typeof this.options.redis !== "undefined" && this.options.redis.enabled) {
+      this.setupRedis();
+    }
 
     this.serversDetails = {};
     this.listenServers = {};
@@ -71,6 +61,24 @@ class Dimensions {
     if (this.options.restApi.enabled) {
       this.restApi = new RestApi(this.options.restApi.port, this.globalTracking, this.serversDetails, this.servers);
     }
+  }
+
+  private setupRedis(): void {
+      // Start a client listening on the dimensions_cli channel for commands, such as reload
+      this.redisClient = redis.createClient({
+        host: this.options.redis.host,
+        port: this.options.redis.port
+      });
+      this.redisClient.subscribe('dimensions_cli');
+      this.redisClient
+        .on('message', (channel: string, message: string) => {
+          if (channel === "dimensions_cli") {
+            this.handleCommand(message);
+          }
+        })
+        .on('error', (err: Error) => {
+          console.log("RedisError: " + err);
+        });
   }
 
   /**

--- a/spec/dimensions/clientcommandhandlerspec.ts
+++ b/spec/dimensions/clientcommandhandlerspec.ts
@@ -65,8 +65,12 @@ describe("ClientCommandHandler", () => {
             connectionRateLimit: {
                 enabled: false,
                 connectionRateLimitPerIP: 5
-            }
-
+            },
+            redis: {
+                enabled: false,
+                host: "localhost",
+                port: 6379
+            },
         };
         mitm = Mitm();
         clientSocketDataHandlers = [];

--- a/spec/dimensions/clientspec.ts
+++ b/spec/dimensions/clientspec.ts
@@ -67,8 +67,12 @@ describe("client", () => {
             connectionRateLimit: {
                 enabled: false,
                 connectionRateLimitPerIP: 5
-            }
-
+            },
+            redis: {
+                enabled: false,
+                host: "localhost",
+                port: 6379
+            },
         };
         mitm = Mitm();
         clientSocketDataHandlers = [];


### PR DESCRIPTION
Adds a config option for server operators that do not want to use the detached reloading option. This will stop Dimensions from trying to connect to a redis server.