### PR TITLE
Use allocUnsafe as it is more performant than alloc

### DIFF
--- a/node_modules/dimensions/packets/bufferwriter.ts
+++ b/node_modules/dimensions/packets/bufferwriter.ts
@@ -8,7 +8,7 @@ class BufferWriter implements Writer {
     protected _offset: number = 0;
 
     constructor(size: number) {
-        this._buffer = Buffer.alloc(size);
+        this._buffer = Buffer.allocUnsafe(size);
     }
 
     public changeOffset(offset: number) {


### PR DESCRIPTION
allocUnsafe in this scenario is fine because all bytes are written to.