### PR TITLE
feat: localized kick

### DIFF
--- a/app/node_modules/dimensions/packets/bufferreader.ts
+++ b/app/node_modules/dimensions/packets/bufferreader.ts
@@ -198,6 +198,18 @@ class BufferReader {
         const mode = this.readByte();
         const text = this.readString();
 
+        // If mode is not Literal
+        if (mode != 0) {
+            // Parse the substitution list
+            const substitutionListLength = this.readByte();
+            if (substitutionListLength > 0) {
+                const substitutionList = new Array<NetworkText>(substitutionListLength);
+                for (let i = 0; i < substitutionListLength; i++) {
+                    substitutionList[i] = this.readNetworkText();
+                }
+            }
+        }
+
         return new NetworkText(mode, text);
     }
 }

--- a/app/node_modules/dimensions/packets/bufferreader.ts
+++ b/app/node_modules/dimensions/packets/bufferreader.ts
@@ -197,20 +197,22 @@ class BufferReader {
     public readNetworkText(): NetworkText {
         const mode = this.readByte();
         const text = this.readString();
+        let substitutionList: NetworkText[] | undefined;
 
         // If mode is not Literal
         if (mode != 0) {
             // Parse the substitution list
             const substitutionListLength = this.readByte();
+
             if (substitutionListLength > 0) {
-                const substitutionList = new Array<NetworkText>(substitutionListLength);
+                substitutionList = new Array<NetworkText>(substitutionListLength);
                 for (let i = 0; i < substitutionListLength; i++) {
                     substitutionList[i] = this.readNetworkText();
                 }
             }
         }
 
-        return new NetworkText(mode, text);
+        return new NetworkText(mode, text, substitutionList);
     }
 }
 

--- a/app/node_modules/dimensions/packets/bufferwriter.ts
+++ b/app/node_modules/dimensions/packets/bufferwriter.ts
@@ -112,6 +112,7 @@ class BufferWriter implements Writer {
         this.packString(networkText.text);
 
         if (networkText.substitutionList) {
+            this.packByte(networkText.substitutionList.length);
             for (let i = 0; i < networkText.substitutionList.length; i++)
             {
                 this.packNetworkText(networkText.substitutionList[i]);

--- a/app/node_modules/dimensions/packets/bufferwriter.ts
+++ b/app/node_modules/dimensions/packets/bufferwriter.ts
@@ -111,9 +111,11 @@ class BufferWriter implements Writer {
         this.packByte(networkText.mode);
         this.packString(networkText.text);
 
-        for (let i = 0; i < networkText.substitutionList.length; i++)
-        {
-            this.packNetworkText(networkText.substitutionList[i]);
+        if (networkText.substitutionList) {
+            for (let i = 0; i < networkText.substitutionList.length; i++)
+            {
+                this.packNetworkText(networkText.substitutionList[i]);
+            }
         }
 
         return this;

--- a/app/node_modules/dimensions/packets/bufferwriter.ts
+++ b/app/node_modules/dimensions/packets/bufferwriter.ts
@@ -110,6 +110,12 @@ class BufferWriter implements Writer {
     public packNetworkText(networkText: NetworkText) {
         this.packByte(networkText.mode);
         this.packString(networkText.text);
+
+        for (let i = 0; i < networkText.substitutionList.length; i++)
+        {
+            this.packNetworkText(networkText.substitutionList[i]);
+        }
+
         return this;
     }
 

--- a/app/node_modules/dimensions/packets/bufferwriter.ts
+++ b/app/node_modules/dimensions/packets/bufferwriter.ts
@@ -117,6 +117,8 @@ class BufferWriter implements Writer {
             {
                 this.packNetworkText(networkText.substitutionList[i]);
             }
+        } else if (networkText.mode != 0) {
+            this.packByte(0);
         }
 
         return this;

--- a/app/node_modules/dimensions/packets/networktext.ts
+++ b/app/node_modules/dimensions/packets/networktext.ts
@@ -1,10 +1,12 @@
 class NetworkText {
     private _mode: number;
     private _text: string;
+    private _substitutionList: NetworkText[];
 
-    constructor(mode: number, text: string) {
+    constructor(mode: number, text: string, substitutionList: NetworkText[] = null) {
         this._mode = mode;
         this._text = text;
+        this._substitutionList = substitutionList;
     }
 
     public get mode(): number {
@@ -13,6 +15,10 @@ class NetworkText {
 
     public get text(): string {
         return this._text;
+    }
+
+    public get substitutionList(): NetworkText[] {
+        return this._substitutionList;
     }
 
     public toString(): string {

--- a/app/node_modules/dimensions/packets/networktext.ts
+++ b/app/node_modules/dimensions/packets/networktext.ts
@@ -1,9 +1,9 @@
 class NetworkText {
     private _mode: number;
     private _text: string;
-    private _substitutionList: NetworkText[];
+    private _substitutionList: NetworkText[] | undefined;
 
-    constructor(mode: number, text: string, substitutionList: NetworkText[] = null) {
+    constructor(mode: number, text: string, substitutionList: NetworkText[] | undefined = undefined) {
         this._mode = mode;
         this._text = text;
         this._substitutionList = substitutionList;
@@ -17,7 +17,7 @@ class NetworkText {
         return this._text;
     }
 
-    public get substitutionList(): NetworkText[] {
+    public get substitutionList(): NetworkText[] | undefined {
         return this._substitutionList;
     }
 

--- a/app/node_modules/dimensions/packets/packetwriter.ts
+++ b/app/node_modules/dimensions/packets/packetwriter.ts
@@ -115,6 +115,15 @@ class PacketWriter implements Writer {
     public packNetworkText(networkText: NetworkText) {
         this.packByte(networkText.mode);
         this.packString(networkText.text);
+
+        if (networkText.substitutionList) {
+            this.packByte(networkText.substitutionList.length);
+            for (let i = 0; i < networkText.substitutionList.length; i++)
+            {
+                this.packNetworkText(networkText.substitutionList[i]);
+            }
+        }
+
         return this;
     }
 

--- a/app/node_modules/dimensions/packets/packetwriter.ts
+++ b/app/node_modules/dimensions/packets/packetwriter.ts
@@ -122,6 +122,8 @@ class PacketWriter implements Writer {
             {
                 this.packNetworkText(networkText.substitutionList[i]);
             }
+        } else if (networkText.mode != 0) {
+            this.packByte(0);
         }
 
         return this;

--- a/app/node_modules/dimensions/terrariaserverpackethandler.ts
+++ b/app/node_modules/dimensions/terrariaserverpackethandler.ts
@@ -168,12 +168,6 @@ class TerrariaServerPacketHandler {
       var dcReason = reader.readNetworkText();
       var color = "C8FF00";
       var message = "[The dimension you were in disconnected you]";
-      var dcReasonText = dcReason.text;
-      switch (dcReasonText) {
-        case "Net.PlayerIsCreativeAndWorldIsNotCreative":
-          dcReasonText = "You can only join that Dimension using a non-journey character.";
-          break;
-      }
       client.sendChatMessage(message, color);
       client.sendChatMessage(new NetworkText(1, "Reason: {0}", [ dcReason ]), color);
       client.wasKicked = true;

--- a/app/node_modules/dimensions/terrariaserverpackethandler.ts
+++ b/app/node_modules/dimensions/terrariaserverpackethandler.ts
@@ -1,4 +1,5 @@
 import PacketTypes from 'dimensions/packettypes';
+import NetworkText from 'dimensions/packets/networktext';
 import PacketReader from 'dimensions/packets/packetreader';
 import PacketWriter from 'dimensions/packets/packetwriter';
 import { getProperIP, getPackedStringByteLen } from 'dimensions/utils';
@@ -174,7 +175,7 @@ class TerrariaServerPacketHandler {
           break;
       }
       client.sendChatMessage(message, color);
-      client.sendChatMessage("Reason: " + dcReasonText, color);
+      client.sendChatMessage(new NetworkText(1, "Reason: {0}", [ dcReason ]), color);
       client.wasKicked = true;
       client.connected = false;
 


### PR DESCRIPTION
- Added support to `NetworkText` for substitution lists for mode 1(formattable) and 2(localization key)
- Added read/write support(`BufferReader`, `BufferWriter`, `PacketWriter`) for substitution lists
- Changed in-game kick to use formattable `NetworkText` instead of literal `NetworkText`. In other words, vanilla kick reasons such as `LegacyMultiplayer.5` should be automatically translated by the client to `{0} is already on this server.`
- The hardcoded `Net.PlayerIsCreativeAndWorldIsNotCreative` translation was left untouched because it is not the same as the client version