### PR TITLE
fix: extensions do not have access to `listenServers` when using `setListenServers` method, due to overwritten reference inside the Dimensions class; cleanup fn for extensions

### DIFF
--- a/app/node_modules/dimensions/index.ts
+++ b/app/node_modules/dimensions/index.ts
@@ -199,7 +199,7 @@ class Dimensions {
     }
   }
 
-  /** Unload all extensions, regardless if `extensionLoad` flag is set or not. */
+  /** Unloads all extensions. */
   private unloadExtensions() {
     for (let key in this.handlers.extensions) {
         let extension = this.handlers.extensions[key];
@@ -210,13 +210,15 @@ class Dimensions {
           }
         }
 
-        this.logging.info(`[Extension] ${extension.name} ${extension.version} unloaded.`);
+        if (this.options.log.extensionLoad) {
+            this.logging.info(`[Extension] ${extension.name} ${extension.version} unloaded.`);
+        }
     }
   }
 
   /* Unloads and re-loads all extensions directly from their directories */
   private reloadExtensions(): void {
-    if (this.options.log.extensionLoad) this.unloadExtensions();
+    this.unloadExtensions();
 
     this.handlers.extensions = {};
     Object.keys(require.cache).forEach(key => delete require.cache[key]);

--- a/app/node_modules/dimensions/index.ts
+++ b/app/node_modules/dimensions/index.ts
@@ -54,9 +54,6 @@ class Dimensions {
       this.setupRedis();
     }
 
-    this.serversDetails = {};
-    this.listenServers = {};
-    this.servers = {};
     this.globalTracking = {
       names: {}
     };
@@ -202,10 +199,9 @@ class Dimensions {
     }
   }
 
-  /* Unloads and re-loads all extensions directly from their directories */
-  private reloadExtensions(): void {
-    if (this.options.log.extensionLoad) {
-      for (let key in this.handlers.extensions) {
+  /** Unload all extensions, regardless if `extensionLoad` flag is set or not. */
+  private unloadExtensions() {
+    for (let key in this.handlers.extensions) {
         let extension = this.handlers.extensions[key];
         if (extension.unload) {
           const storage = extension.unload();
@@ -214,11 +210,13 @@ class Dimensions {
           }
         }
 
-        if (this.options.log.extensionLoad) {
-          this.logging.info(`[Extension] ${extension.name} ${extension.version} unloaded.`);
-        }
-      }
+        this.logging.info(`[Extension] ${extension.name} ${extension.version} unloaded.`);
     }
+  }
+
+  /* Unloads and re-loads all extensions directly from their directories */
+  private reloadExtensions(): void {
+    if (this.options.log.extensionLoad) this.unloadExtensions();
 
     this.handlers.extensions = {};
     Object.keys(require.cache).forEach(key => delete require.cache[key]);
@@ -319,7 +317,9 @@ class Dimensions {
       this.restApi.close();
     }
 
-    Object.keys(this.listenServers).forEach(key => this.listenServers[key].shutdown());
+    this.unloadExtensions();
+
+    Object.values(this.listenServers).forEach(server => server.shutdown()); 
   }
 }
 


### PR DESCRIPTION
Hi @popstarfreas,

I found a bug that extensions can't use the `listenServers` provided by the `setListenServers` method, because it is set to `{}` during the entire lifecycle of the service. I found out that the root cause of it is that the `listenServers` property in class Dimensions gets overwritten after the `setListenServers` method is called. Because of that, when Dimensions updates the `listenServers`, it's not visible inside the extensions. The `listenServers` don't need to be set to `{}` there, as it's been already initialized anyway, so fortunately it's easy to fix.

Also, I created a new method `unloadExtensions` (based on your implementation of `reloadExtensions`) and I'm calling it in the `dimensions.close()` method to provide a way for extensions to cleanup resources when the service exits.

Btw, would it be possible to mention my extension in the README, e.g in the "Extensions" section? Thanks in advance
https://github.com/Zazzik1/SwitchServersByAPI
