### PR TITLE
Fix mana and health restoration when switching from SSC to Non-SSC server

### DIFF
--- a/app/node_modules/dimensions/clientpackethandler.ts
+++ b/app/node_modules/dimensions/clientpackethandler.ts
@@ -292,8 +292,8 @@ class ClientPacketHandler {
     if (typeof playerMana === 'undefined') {
       return true;
     }
-    const { mana } = playerMana;
-    this.currentClient.player.mana = mana;
+    const { maxMana } = playerMana;
+    this.currentClient.player.mana = maxMana;
     this.currentClient.player.allowedManaChange = false;
 
     return false;
@@ -311,8 +311,8 @@ class ClientPacketHandler {
       return true;
     }
 
-    const { health } = playerHealth;
-    this.currentClient.player.life = health;
+    const { maxHealth } = playerHealth;
+    this.currentClient.player.life = maxHealth;
     this.currentClient.player.allowedLifeChange = false;
 
     // Prevent this being sent too early (causing kicked for invalid operation)


### PR DESCRIPTION
Previously, when restoring mana and health after switching from an SSC server to a Non-SSC server, the current values were used instead of the maximum values. This caused unintended changes to the player's maximum mana and health. Now, the restoration correctly sets the maximum values.