### PR TITLE
feat: clear journey powers

### DIFF
--- a/app/node_modules/dimensions/clearutils.ts
+++ b/app/node_modules/dimensions/clearutils.ts
@@ -121,6 +121,61 @@ class ClearUtils {
       client.socket.write(loadNetModulePacket);
     }
   }
+
+  private static _falseArray255 = Array(255).fill(false);
+
+  // These packets don't change and only need to be created once
+  private static _journeyClearPackets = [
+    // Per player powers activate before the destination server syncs them
+    // when switching dimensions. Therefore, there is a brief moment when
+    // they are active. To avoid this situation, they must be zeroed when
+    // switching dimensions.
+    LoadNetModule.toBuffer({
+      TAG: "CreativePower",
+      _0: {
+        TAG: "GodmodePower",
+        _0: {
+          TAG: "Everyone",
+          _0: this._falseArray255,
+        },
+      },
+    }),
+    LoadNetModule.toBuffer({
+      TAG: "CreativePower",
+      _0: {
+        TAG: "FarPlacementRangePower",
+        _0: {
+          TAG: "Everyone",
+          _0: this._falseArray255,
+        },
+      },
+    }),
+    ...Array.from({length: 255}, (_, i) => (
+      LoadNetModule.toBuffer({
+        TAG: "CreativePower",
+        _0: {
+          TAG: "SpawnRateSliderPerPlayerPower",
+          _0: {
+            playerId: i,
+            value: 0,
+          },
+        },
+      })
+    )),
+  ];
+
+  public static clearJourneyPowers(client: Client): void {
+    for (const buffer of this._journeyClearPackets) {
+      const packet = {
+        data: buffer,
+        packetType: PacketTypes.LoadNetModule,
+      };
+      const processedData = client.server.getPacketHandler().handlePacket(client.server, packet);
+      if (processedData !== null) {
+        client.socket.write(processedData);
+      }
+    }
+  }
 }
 
 export default ClearUtils;

--- a/app/node_modules/dimensions/client.ts
+++ b/app/node_modules/dimensions/client.ts
@@ -391,6 +391,7 @@ class Client {
     ClearUtils.clearNPCs(this);
     ClearUtils.clearItems(this);
     ClearUtils.clearPylons(this);
+    ClearUtils.clearJourneyPowers(this);
 
     let ip: string = server.serverIP;
     let port: number = server.serverPort;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "glob": "^7.2.0",
         "redis": "^3.1.2",
         "require-nocache": "^1.0.0",
-        "terraria-packet": "github:popstarfreas/rescript-terrariapacket#39d3ba5c77ebe4a8cfc1c2b67d8ae4cbac479379",
+        "terraria-packet": "github:popstarfreas/rescript-terrariapacket#28e9669eed6a57b011e0bca010a6e14348487db0",
         "utf8": "^3.0.0",
         "uuid": "^8.3.2",
         "winston": "^3.12.0"
@@ -611,8 +611,8 @@
     },
     "node_modules/terraria-packet": {
       "version": "1.2.0",
-      "resolved": "git+ssh://git@github.com/popstarfreas/rescript-terrariapacket.git#39d3ba5c77ebe4a8cfc1c2b67d8ae4cbac479379",
-      "integrity": "sha512-VA+peo0zSXXqs1nAzUze/GNvHUUoIyEQ5FcTOmaY++XfEnUJdaoFQXCFiL1HX4znyJaTZNxH0RLK284FEBdFIw==",
+      "resolved": "git+ssh://git@github.com/popstarfreas/rescript-terrariapacket.git#28e9669eed6a57b011e0bca010a6e14348487db0",
+      "integrity": "sha512-Tipy3C4T3+lJ4fF8IaYGCoHz+o9ji8w9KGbwJHeNjnxdqLcHRh1NZ4IxDp3qPefPMRCKMMxJVDgMWTAQVVwgyg==",
       "dependencies": {
         "@popstarfreas/packetfactory": "^6.1.1",
         "@popstarfreas/rescript-nodejs": "git+https://github.com/popstarfreas/rescript-nodejs.git#f3bd284a3ef17a3fc7cc81ccb7c362b278ea66c7",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "glob": "^7.2.0",
     "redis": "^3.1.2",
     "require-nocache": "^1.0.0",
-    "terraria-packet": "github:popstarfreas/rescript-terrariapacket#39d3ba5c77ebe4a8cfc1c2b67d8ae4cbac479379",
+    "terraria-packet": "github:popstarfreas/rescript-terrariapacket#28e9669eed6a57b011e0bca010a6e14348487db0",
     "utf8": "^3.0.0",
     "uuid": "^8.3.2",
     "winston": "^3.12.0",


### PR DESCRIPTION
This pull request introduces a new function in `clearutils.ts`. This function is designed to clear all journey powers associated with each player. This action occurs specifically during a dimensional transition, but crucially, before the player's game client receives the journey power synchronization packets from the server. The aim of this change is to prevent the accidental or unintended activation of journey powers during the transition process.

Shared or server-wide powers are not cleared because they do not activate during transition. Furthermore, they are synced later when the player joins the server.
