### PR TITLE
fix: client unnecessarily resyncing powers after switching dimensions

### DIFF
--- a/app/node_modules/dimensions/clearutils.ts
+++ b/app/node_modules/dimensions/clearutils.ts
@@ -124,21 +124,23 @@ class ClearUtils {
     }
   }
 
-  private static _falseArray255 = Array(255).fill(false);
+  private static _godmodePowerDefault = false;
+  private static _farPlacementRangePowerDefault = true;
+  private static _spawnRateSliderDefault = 0.5;
 
   // These packets don't change and only need to be created once
   private static _journeyClearPackets = [
     // Per player powers activate before the destination server syncs them
     // when switching dimensions. Therefore, there is a brief moment when
-    // they are active. To avoid this situation, they must be zeroed when
-    // switching dimensions.
+    // they are active. To avoid this situation, they must be set to their
+    // default values when switching dimensions
     NetModuleLoadPacket.toBuffer({
       TAG: "CreativePower",
       _0: {
         TAG: "GodmodePower",
         _0: {
           TAG: "Everyone",
-          _0: this._falseArray255,
+          _0: Array(255).fill(this._godmodePowerDefault),
         },
       },
     }),
@@ -148,7 +150,7 @@ class ClearUtils {
         TAG: "FarPlacementRangePower",
         _0: {
           TAG: "Everyone",
-          _0: this._falseArray255,
+          _0: Array(255).fill(this._farPlacementRangePowerDefault),
         },
       },
     }),
@@ -159,7 +161,7 @@ class ClearUtils {
           TAG: "SpawnRateSliderPerPlayerPower",
           _0: {
             playerId: i,
-            value: 0,
+            value: this._spawnRateSliderDefault,
           },
         },
       })
@@ -167,7 +169,32 @@ class ClearUtils {
   ];
 
   public static clearJourneyPowers(client: Client): void {
-    for (const buffer of this._journeyClearPackets) {
+    const packets = [
+      ...this._journeyClearPackets,
+      NetModuleLoadPacket.toBuffer({
+        TAG: "CreativePower",
+        _0: {
+          TAG: "GodmodePower",
+          _0: {
+            TAG: "Player",
+            _0: client.player.id,
+            _1: this._godmodePowerDefault
+          }
+        }
+      }),
+      NetModuleLoadPacket.toBuffer({
+        TAG: "CreativePower",
+        _0: {
+          TAG: "FarPlacementRangePower",
+          _0: {
+            TAG: "Player",
+            _0: client.player.id,
+            _1: this._farPlacementRangePowerDefault
+          }
+        }
+      })
+    ];
+    for (const buffer of packets) {
       if (buffer.TAG === "Ok") {
         const packet = {
           data: buffer._0,


### PR DESCRIPTION
- Sets powers to their default values assumed by the client instead of 0. This prevents the client from resyncing because their stored value is different
- Fixes godmode power and far placement range power not being properly reset for the player's current index