### PR TITLE
Fix proxy switch handshake: send valid GetSection packet (include tea…

### DIFF
--- a/app/dimensions/terrariaserverpackethandler.ts
+++ b/app/dimensions/terrariaserverpackethandler.ts
@@ -300,6 +300,7 @@ class TerrariaServerPacketHandler {
         .setType(PacketTypes.GetSectionOrRequestSync)
         .packSingle(-1)
         .packSingle(-1)
+        .packByte(0)
         .data;
       this.currentServer.sendDirect(getSection);
 


### PR DESCRIPTION
…m byte)

Root cause: GetSectionOrRequestSync (packet 8) built with invalid length during server switch (11 instead of 12). Added missing team byte (packByte(0)) in handleWorldInfo. This prevents TShock EndOfStream in HandleGetSection and eliminates kick: Your client didn't send the right connection information. Removed temporary chat-drop workaround used during debugging.